### PR TITLE
Declare ember-browser-services as peer dependency

### DIFF
--- a/ember-oss-docs/package.json
+++ b/ember-oss-docs/package.json
@@ -46,6 +46,7 @@
     "@glint/environment-ember-loose": "^0.9.4 || ^1.0.0-beta.1",
     "@glint/template": ">= 0.9.0 || ^1.0.0-beta.1",
     "@tailwindcss/typography": "^0.5.7",
+    "ember-browser-services": "^4.0.4",
     "highlight.js": "^11.6.0",
     "highlightjs-glimmer": "^1.4.1 || ^2.0.0"
   },


### PR DESCRIPTION
Not having this in a consuming app makes the build fail. It is already a dev dependency here, but missing to declare as a peer.