### PR TITLE
fix: Code blocks, remove backticks

### DIFF
--- a/ember-oss-docs/src/styles/docfy-overrides.css
+++ b/ember-oss-docs/src/styles/docfy-overrides.css
@@ -20,6 +20,21 @@ h2#examples {
   @apply interactive-disabled;
 }
 
+.prose :where(code):not(:where([class~='not-prose'] *)) {
+  background-color: var(--basement);
+  padding-right: 0.25rem;
+  padding-left: 0.25rem;
+  border-radius: 0.25rem;
+}
+
+.prose :where(code):not(:where([class~='not-prose'] *))::before {
+  content: '';
+}
+
+.prose :where(code):not(:where([class~='not-prose'] *))::after {
+  content: '';
+}
+
 .docfy-demo__snippet {
   max-height: 30rem;
   overflow-y: scroll;
@@ -41,6 +56,7 @@ h2#examples {
 .docfy-collection .docfy-demo__snippet {
   overflow-x: auto;
 }
+
 
 .docfy-collection .docfy-demo__example {
   @apply grid justify-items-center;


### PR DESCRIPTION
Related issue: https://github.com/CrowdStrike/ember-oss-docs/issues/14

Docfy styles code blocks with backticks.

This change changes the background to `--basement` and adds a bit of padding with rounded corners.

## Before
<img width="812" alt="before" src="https://github.com/CrowdStrike/ember-oss-docs/assets/771170/f05d13b5-4f3a-4ff0-9455-02d469bf95f4">

## After
<img width="637" alt="after" src="https://github.com/CrowdStrike/ember-oss-docs/assets/771170/27b858c6-0158-480b-8b8c-84cc08d7d27f">

