### PR TITLE
fix: specify page-title as helper for embroider

### DIFF
--- a/ember-oss-docs/src/components/docs-wrapper/index.hbs
+++ b/ember-oss-docs/src/components/docs-wrapper/index.hbs
@@ -1,9 +1,9 @@
 <div class="px-4 mx-auto lg:px-6 max-w-screen-2xl w-full">
   <DocfyOutput @fromCurrentURL={{true}} as |page|>
-    {{page-title "Documentation"}}
+    {{(page-title "Documentation")}}
 
     {{#unless page.frontmatter.hideTitle}}
-      {{page-title page.title}}
+      {{(page-title page.title)}}
     {{/unless}}
 
   </DocfyOutput>


### PR DESCRIPTION
Embroider appears to be confused on if this is a helper or a component, so let's help it out!

```bash
docs-app:build: $TMPDIR/embroider/e83321/node_modules/.pnpm/@crowdstrike+ember-oss-docs@1.1.3_@babel+core@7.20_fpozsm2o5k5eo5xywztlg5s4ga/node_modules/@crowdstrike/ember-oss-docs/dist/components/docs-wrapper/index.js/index.js: unsupported ambiguity between helper and component: this use of "{{page-title}}" could be helper "{{ (page-title) }}" or component "<PageTitle />", and your settings for staticHelpers and staticComponents do not agree. Either switch to one of the unambiguous forms, or make staticHelpers and staticComponents agree, or use a "disambiguate" packageRule to work around the problem if its in third-party code you cannot easily fix. in $TMPDIR/embroider/e83321/node_modules/.pnpm/@crowdstrike+ember-oss-docs@1.1.3_@babel+core@7.20_fpozsm2o5k5eo5xywztlg5s4ga/node_modules/@crowdstrike/ember-oss-docs/dist/components/docs-wrapper/index.js
```

This error is coming from toucan-core when we are attempting to use the latest version of embroider: https://github.com/CrowdStrike/ember-toucan-core/actions/runs/5333735858/jobs/9664616418?pr=163