### PR TITLE
Fix use of page-title helper, causing GlimmerVM exceptions

### DIFF
--- a/ember-oss-docs/src/components/docs-wrapper/index.hbs
+++ b/ember-oss-docs/src/components/docs-wrapper/index.hbs
@@ -1,9 +1,9 @@
 <div class="px-4 mx-auto lg:px-6 max-w-screen-2xl w-full">
   <DocfyOutput @fromCurrentURL={{true}} as |page|>
-    {{(page-title "Documentation")}}
+    {{page-title "Documentation"}}
 
     {{#unless page.frontmatter.hideTitle}}
-      {{(page-title page.title)}}
+      {{page-title page.title}}
     {{/unless}}
 
   </DocfyOutput>


### PR DESCRIPTION
Under some (not sure exactly what) condition, the usage here with the explicit helper invocation would cause GlimmerVM to choke. This isn't what the docs show anyway.

This has been causing https://github.com/CrowdStrike/ember-headless-form/issues/292

Builds on top of #24, so we need to merge that first.